### PR TITLE
Add grafana-annotation-resource

### DIFF
--- a/resources.yml
+++ b/resources.yml
@@ -635,3 +635,10 @@
   repository: https://github.com/pjk25/concourse-opsman-installations-resource
   desc: "Emits a new version when an \"Apply Changes\" completes. Optionally fetch the installation logs."
   get: yes
+- name: Grafana Annotation Resource
+  repository: https://github.com/alphagov/paas-grafana-annotation-resource
+  desc: "Creates or updates a Grafana annotation"
+  put: yes
+  categories:
+    - Notification
+    - Deployment


### PR DESCRIPTION
What
----

Adds the [grafana-annotation-resource](https://github.com/alphagov/paas-grafana-annotation-resource) built by @alphagov

Used for creating and updating Grafana annotations:
![Screen Shot 2019-10-13 at 18 24 04](https://user-images.githubusercontent.com/1482692/66719382-b0717f80-ede6-11e9-86a6-7bd1caf9939b.png)
_Image of a requests per second dashboard with Grafana annotations showing deployment phases_

Why
---

We use Concourse for our many of our deployment pipelines, during which we run API and application availability tests.

It is useful to see the side-effects of these tests on our Grafana dashboards, e.g. elevated 5xx HTTP status codes. Given that Concourse is managing the pipeline, it makes sense to have a Concourse resource for creating/updating annotations.