### PR TITLE
web: finish terms page, footer

### DIFF
--- a/web/src/Common/Common.elm
+++ b/web/src/Common/Common.elm
@@ -9,6 +9,7 @@ module Common.Common exposing
     , footerBackgroundColor
     , gridSize
     , shadowColor
+    , termsLinkColor
     , white
     )
 
@@ -77,19 +78,24 @@ white =
 
 shadowColor : RGB
 shadowColor =
-    { red = 98, blue = 85, green = 85, alpha = 0.2 }
+    { red = 98, green = 85, blue = 85, alpha = 0.2 }
 
 
 cardDescriptionColor : RGB
 cardDescriptionColor =
-    { red = 90, blue = 85, green = 85, alpha = 1 }
+    { red = 90, green = 85, blue = 85, alpha = 1 }
 
 
 cardTitleColor : RGB
 cardTitleColor =
-    { red = 42, blue = 41, green = 41, alpha = 1 }
+    { red = 42, green = 41, blue = 41, alpha = 1 }
 
 
 footerBackgroundColor : RGB
 footerBackgroundColor =
-    { red = 127, blue = 127, green = 127, alpha = 1 }
+    { red = 127, green = 127, blue = 127, alpha = 1 }
+
+
+termsLinkColor : RGB
+termsLinkColor =
+    { red = 12, green = 106, blue = 246, alpha = 1 }

--- a/web/src/Footer/View.elm
+++ b/web/src/Footer/View.elm
@@ -3,13 +3,15 @@ module Footer.View exposing (view)
 import Common.Common as Common exposing (center)
 import Element
     exposing
-        ( Element
+        ( Attribute
+        , Element
         , centerX
         , fill
         , fromRgb255
         , height
         , htmlAttribute
         , link
+        , newTabLink
         , px
         , row
         , spacing
@@ -53,9 +55,9 @@ view =
             ]
             [ showLink terms
             , text "|"
-            , showLink contribute
+            , showLinkExternal contribute
             , text "|"
-            , showLink feedback
+            , showLinkExternal feedback
             ]
         ]
 
@@ -63,10 +65,27 @@ view =
 showLink : Link -> Element msg
 showLink linkValue =
     link
-        [ htmlAttribute (Html.Attributes.class "footer-link") ]
-        { url = linkValue.url
-        , label = text linkValue.text
-        }
+        linkAttributes
+        (linkDetails linkValue)
+
+
+showLinkExternal : Link -> Element msg
+showLinkExternal linkValue =
+    newTabLink
+        linkAttributes
+        (linkDetails linkValue)
+
+
+linkAttributes : List (Attribute msg)
+linkAttributes =
+    [ htmlAttribute (Html.Attributes.class "footer-link") ]
+
+
+linkDetails : Link -> { url : String, label : Element msg }
+linkDetails linkValue =
+    { url = linkValue.url
+    , label = text linkValue.text
+    }
 
 
 terms : Link
@@ -79,12 +98,12 @@ terms =
 contribute : Link
 contribute =
     { text = "Contribute"
-    , url = "http://example.com"
+    , url = "https://github.com/concourse/resource-types/blob/master/README.md"
     }
 
 
 feedback : Link
 feedback =
     { text = "Feedback"
-    , url = "http://example.com"
+    , url = "https://github.com/concourse/resource-types-website/issues/new"
     }

--- a/web/src/Main.elm
+++ b/web/src/Main.elm
@@ -172,7 +172,7 @@ viewResourceTypes model =
 
 viewTerms : List (Element msg)
 viewTerms =
-    [ Terms.view ]
+    [ Terms.view, Footer.view ]
 
 
 buildErrorMessage : Http.Error -> String

--- a/web/src/Terms/Styles.elm
+++ b/web/src/Terms/Styles.elm
@@ -1,9 +1,12 @@
 module Terms.Styles exposing
-    ( bodyFont
+    ( backLinkColor
+    , backLinkPaddingTop
+    , backLinkSize
+    , bodyFont
     , bodySize
-    , containerSpacing
     , containerWidth
     , titleFont
+    , titlePadding
     , titleSize
     )
 
@@ -19,9 +22,23 @@ containerWidth =
     Common.gridSize * 65
 
 
-containerSpacing : Int
-containerSpacing =
-    Common.gridSize * 9
+
+-- Back Link
+
+
+backLinkSize : Int
+backLinkSize =
+    14
+
+
+backLinkPaddingTop : Int
+backLinkPaddingTop =
+    Common.gridSize * 6
+
+
+backLinkColor : Common.RGB
+backLinkColor =
+    Common.termsLinkColor
 
 
 
@@ -36,6 +53,11 @@ titleSize =
 titleFont : String
 titleFont =
     "Roboto Slab"
+
+
+titlePadding : Int
+titlePadding =
+    Common.gridSize * 3
 
 
 

--- a/web/src/Terms/Terms.elm
+++ b/web/src/Terms/Terms.elm
@@ -1,10 +1,12 @@
-module Terms.Terms exposing (Terms, body, container, terms, title)
+module Terms.Terms exposing (Terms, backLink, body, container, terms, title)
 
+import Common.Common as Common
 import Terms.Styles as Styles
 
 
 type alias Terms =
     { container : Container
+    , backLink : BackLink
     , title : Title
     , body : Body
     }
@@ -12,13 +14,20 @@ type alias Terms =
 
 type alias Container =
     { width : Int
-    , spacing : Int
+    }
+
+
+type alias BackLink =
+    { size : Int
+    , paddingTop : Int
+    , color : Common.RGB
     }
 
 
 type alias Title =
     { font : String
     , size : Int
+    , padding : Int
     }
 
 
@@ -30,17 +39,29 @@ type alias Body =
 
 terms : Terms
 terms =
-    { container = container, title = title, body = body }
+    { container = container
+    , backLink = backLink
+    , title = title
+    , body = body
+    }
 
 
 container : Container
 container =
-    { width = Styles.containerWidth, spacing = Styles.containerSpacing }
+    { width = Styles.containerWidth }
+
+
+backLink : BackLink
+backLink =
+    { size = Styles.backLinkSize
+    , paddingTop = Styles.backLinkPaddingTop
+    , color = Styles.backLinkColor
+    }
 
 
 title : Title
 title =
-    { size = Styles.titleSize, font = Styles.titleFont }
+    { size = Styles.titleSize, font = Styles.titleFont, padding = Styles.titlePadding }
 
 
 body : Body

--- a/web/src/Terms/View.elm
+++ b/web/src/Terms/View.elm
@@ -1,6 +1,21 @@
 module Terms.View exposing (view)
 
-import Element exposing (Element, centerX, column, el, paragraph, px, text, width)
+import Element
+    exposing
+        ( Element
+        , centerX
+        , column
+        , el
+        , fill
+        , fromRgb255
+        , height
+        , link
+        , paddingEach
+        , paragraph
+        , px
+        , text
+        , width
+        )
 import Element.Font as Font
 import Terms.Terms exposing (terms)
 
@@ -8,10 +23,25 @@ import Terms.Terms exposing (terms)
 view : Element msg
 view =
     column
-        [ centerX
+        [ height fill
+        , centerX
         , width <| px terms.container.width
         ]
-        [ title, body ]
+        [ backLink, title, body ]
+
+
+backLink : Element msg
+backLink =
+    el
+        [ Font.size terms.backLink.size
+        , paddingEach { padding | top = terms.backLink.paddingTop }
+        , Font.color <| fromRgb255 terms.backLink.color
+        ]
+        (link []
+            { url = "/"
+            , label = text "← Home"
+            }
+        )
 
 
 title : Element msg
@@ -19,6 +49,7 @@ title =
     el
         [ Font.size terms.title.size
         , Font.family [ Font.typeface terms.title.font ]
+        , paddingEach { padding | top = terms.title.padding, bottom = terms.title.padding }
         ]
         (text "Terms of Use")
 
@@ -35,3 +66,12 @@ body =
 termsTest : String
 termsTest =
     "This website is provided solely for your convenience and information. Pivotal Software, Inc. (Pivotal) does not endorse or make any representations about this website, and Pivotal is not responsible for the accuracy, reliability, and suitability of any information, data, opinions, advice or statements made on this website. Pivotal shall not be held liable for any losses or damages incurred by users of this website. Please note that your access to and usage of this website, including any materials, information, services and products described or provided therein, is made solely at your own risk and discretion."
+
+
+padding : { top : Int, right : Int, bottom : Int, left : Int }
+padding =
+    { top = 0
+    , right = 0
+    , bottom = 0
+    , left = 0
+    }

--- a/web/tests/Terms/TermsTests.elm
+++ b/web/tests/Terms/TermsTests.elm
@@ -13,9 +13,14 @@ suite =
             [ test "has a width" <|
                 \_ ->
                     termsContainer.width |> Expect.equal Styles.containerWidth
-            , test "has spacing" <|
-                \_ ->
-                    termsContainer.spacing |> Expect.equal Styles.containerSpacing
+            ]
+        , describe "back link"
+            [ test "has a font size" <|
+                \_ -> termsBackLink.size |> Expect.equal Styles.backLinkSize
+            , test "has top padding" <|
+                \_ -> termsBackLink.paddingTop |> Expect.equal Styles.backLinkPaddingTop
+            , test "has font color" <|
+                \_ -> termsBackLink.color |> Expect.equal Styles.backLinkColor
             ]
         , describe "title"
             [ test "has a font size" <|
@@ -24,6 +29,9 @@ suite =
             , test "has a font" <|
                 \_ ->
                     termsTitle.font |> Expect.equal Styles.titleFont
+            , test "has padding" <|
+                \_ ->
+                    termsTitle.padding |> Expect.equal Styles.titlePadding
             ]
         , describe "body"
             [ test "has a font size" <|
@@ -38,6 +46,10 @@ suite =
 
 termsContainer =
     Terms.container
+
+
+termsBackLink =
+    Terms.backLink
 
 
 termsTitle =


### PR DESCRIPTION
terms page:
- add back link
- add padding

footer: 
- fixed links to go to proper pages

other:
- refactoring across tests/common

notes:
i forgot to bring this commit over in my last big PR, so this will actually fix #155 and #156 