### PR TITLE
web: add navigation from concourse docs site

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -6,6 +6,7 @@
     <link href="https://fonts.googleapis.com/css?family=Barlow&display=swap" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="{{asset "spinner.css"}}">
     <link rel="stylesheet" type="text/css" href="{{asset "overrides.css"}}">
+    <link rel="stylesheet" type="text/css" href="{{asset "navigation.css"}}">
     <link rel="shortcut icon" type="image/x-icon" href="{{asset "favicon.ico"}}" />
   </head>
 

--- a/web/public/navigation.css
+++ b/web/public/navigation.css
@@ -1,0 +1,79 @@
+.top-logo, .top-nav, .top-search {
+  background: #3398dc;
+  color: white;
+  font-family: 'Roboto Slab', serif;
+}
+.top-nav {
+  position: relative;
+  white-space: nowrap;
+}
+.top-logo a {
+  color: white;
+  margin: 0;
+  font-size: 22px;
+  padding: 0 50px 0 80px;
+  line-height: 80px;
+  display: inline-block;
+  vertical-align: top;
+  text-decoration: none;
+  position: relative;
+}
+.top-logo img {
+  width: 40px;
+  height: 40px;
+  vertical-align: middle;
+  position: absolute;
+  top: 18px;
+  left: 17px;
+}
+.top-logo a:visited {
+  color: white;
+}
+.top-link {
+  color: white;
+  font-size: 16px;
+  text-transform: lowercase;
+  line-height: 80px;
+  display: inline-block;
+  padding: 0 25px;
+  margin-right: 4px;
+}
+.top-link, .top-link:visited {
+  color: white;
+  text-decoration: none;
+}
+.top-link:hover {
+  color: white;
+  text-decoration: underline;
+}
+.top-link.active {
+  background: white;
+  color: #2a2929;
+  text-decoration: underline;
+}
+.top-logo {
+  grid-area: logo;
+}
+.top-nav {
+  grid-area: primary-nav;
+}
+.top-search {
+  grid-area: search;
+}
+.navigation {
+  display: grid;
+  grid-template-columns: 2fr 5fr 3fr;
+  grid-template-areas: "logo primary-nav search";
+  width: 100%;
+}
+@media (max-width: 1200px) {
+  .navigation {
+    grid-template-columns: 5fr 2fr;
+    grid-template-areas: "logo search" "primary-nav primary-nav";
+  }
+  .top-nav a {
+    line-height: 60px;
+    vertical-align: top;
+  }
+}
+

--- a/web/src/Common/Common.elm
+++ b/web/src/Common/Common.elm
@@ -41,7 +41,7 @@ type alias ResourceType =
     { name : String
     , url : String
     , description : String
-    , username: String
+    , username : String
     }
 
 

--- a/web/src/Main.elm
+++ b/web/src/Main.elm
@@ -6,8 +6,8 @@ import Browser.Navigation as Nav
 import Common.Common exposing (ResourceType, gridSize)
 import Element exposing (Element, centerX, column, el, fill, height, html, padding, text, width)
 import Footer.View as Footer exposing (view)
-import Html
-import Html.Attributes exposing (class)
+import Html exposing (a, div, img, nav)
+import Html.Attributes exposing (class, href, src)
 import Http
 import Json.Decode as Decode exposing (Decoder, list, string)
 import Json.Decode.Pipeline exposing (optional, required)
@@ -86,12 +86,14 @@ view model =
                 [ width fill
                 , height fill
                 ]
-                (case model.page of
-                    Index ->
-                        viewResourceTypes model
+                (html navigation
+                    :: (case model.page of
+                            Index ->
+                                viewResourceTypes model
 
-                    Terms ->
-                        viewTerms
+                            Terms ->
+                                viewTerms
+                       )
                 )
             )
         ]
@@ -221,3 +223,43 @@ resourceTypeDecoder =
         |> required "repo" string
         |> optional "description" string ""
         |> required "username" string
+
+
+
+-- top navigation from the concourse docs site
+
+
+navigation : Html.Html msg
+navigation =
+    let
+        baseUrl =
+            "https://concourse-ci.org/"
+
+        blogUrl =
+            "https://blog.concourse-ci.org"
+
+        discussUrl =
+            "https://discuss.concourse-ci.org"
+    in
+    div [ class "navigation" ]
+        [ div [ class "top-logo" ]
+            [ a [ href baseUrl ]
+                [ img
+                    [ src <| baseUrl ++ "images/logo-white.svg" ]
+                    []
+                , Html.text "Concourse"
+                ]
+            ]
+        , nav
+            [ class "top-nav" ]
+            [ a [ href <| baseUrl ++ "docs", class "top-link" ] [ Html.text "docs" ]
+            , a [ href <| baseUrl ++ "examples", class "top-link" ] [ Html.text "examples" ]
+            , a [ href <| baseUrl ++ "project", class "top-link" ] [ Html.text "project" ]
+            , a [ href <| blogUrl, class "top-link" ] [ Html.text "blog" ]
+            , a [ href <| discussUrl, class "top-link" ] [ Html.text "discuss" ]
+            , a [ href "/", class "top-link active" ] [ Html.text "resource types" ]
+            ]
+        , div
+            [ class "top-search" ]
+            [ Html.text "" ]
+        ]


### PR DESCRIPTION
this adds a very close version of the navigation used on the concourse-ci.org docs/discuss/blog

a bit of process behind the decision to use normal elm html in the midst of our elm-ui for the navigation...

1. the layout on the concourse docs site for the navigation is very simple, couple divs, nav, some anchor tags, elm ui would make us do a row with some paragraphs and rows inside, so we already have strayed from the consistent navigation structure used on three other sites
2. tried throwing it in the body of index.html, but elm init overrides the body completely
3. ended up using elm html because we can keep the exact same structure, plus just pull in the bits and pieces from the css that we need. much faster, and much closer to the original.

note: i started doing this tdd'n elm-ui, but i was about 3 or 4 hours in and started struggling with the smaller details (margins on both sides of the links, among other things) before looking for a quicker way. using the css from the docs site keeps it very consistent.

(until i used a freedom friday to do it in elm-ui perfectly as a challenge)

part of concourse/resource-types-website#37

**note: this needs design acceptance after merge**
