### PR TITLE
web: capitalize the first letter of card description

### DIFF
--- a/web/elm.json
+++ b/web/elm.json
@@ -13,12 +13,14 @@
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
             "elm/url": "1.0.0",
+            "elm-community/string-extra": "4.0.1",
             "krisajenkins/remotedata": "6.0.1",
             "mdgriffith/elm-ui": "1.1.5"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
+            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2"
         }

--- a/web/src/Card/View.elm
+++ b/web/src/Card/View.elm
@@ -1,6 +1,7 @@
 module Card.View exposing (view)
 
 import Card.Card exposing (Author, Description, Github, Name, card)
+import String.Extra exposing (toSentenceCase)
 import Common.Common exposing (ResourceType)
 import Common.Overrides as Overrides exposing (ellipsis, multiLineEllipsis)
 import Element
@@ -117,7 +118,7 @@ description resourceType styles =
         [ html
             (Html.div
                 (Overrides.multiLineEllipsis 2)
-                [ Html.text resourceType.description ]
+                [ Html.text (toSentenceCase resourceType.description) ]
             )
         ]
 


### PR DESCRIPTION
uses elm-communities string.extra toSentenceCase, pretty nice!

finishes concourse/resource-types-website#179

**note: this needs design acceptance after merge**