### PR TITLE
web: make card description 3 lines

### DIFF
--- a/web/src/Card/Styles.elm
+++ b/web/src/Card/Styles.elm
@@ -148,7 +148,7 @@ descriptionFont =
 
 descriptionPaddingTop : Int
 descriptionPaddingTop =
-    Common.gridSize * 2
+    Common.gridSize + Common.gridSize // 2
 
 
 descriptionColor : RGB

--- a/web/src/Card/View.elm
+++ b/web/src/Card/View.elm
@@ -98,7 +98,6 @@ author resourceType styles =
         , Font.color <| fromRgb255 styles.color
         , paddingEach { padding | top = styles.paddingTop }
         ]
-        -- it'll be resourceType.author or whatever here
         [ text resourceType.username ]
 
 
@@ -116,7 +115,7 @@ description resourceType styles =
         ]
         [ html
             (Html.div
-                (Overrides.multiLineEllipsis 2)
+                (Overrides.multiLineEllipsis 3)
                 [ Html.text resourceType.description ]
             )
         ]

--- a/web/src/Common/Common.elm
+++ b/web/src/Common/Common.elm
@@ -41,7 +41,7 @@ type alias ResourceType =
     { name : String
     , url : String
     , description : String
-    , username: String
+    , username : String
     }
 
 

--- a/web/src/Common/Overrides.elm
+++ b/web/src/Common/Overrides.elm
@@ -34,4 +34,5 @@ multiLineEllipsis numLines =
     , Html.Attributes.style "display" "-webkit-box"
     , Html.Attributes.style "-webkit-line-clamp" (String.fromInt numLines)
     , Html.Attributes.style "-webkit-box-orient" "vertical"
+    , Html.Attributes.style "word-break" "break-word"
     ]


### PR DESCRIPTION
this pr makes the description on a card 3 lines, also does a bit of movement with spacing

went with break word instead of break all with hyphens... we can iterate! :)

finishes concourse/resource-types-website#178
