### PR TITLE
web: fix footer when loading spinner

### DIFF
--- a/web/src/Main.elm
+++ b/web/src/Main.elm
@@ -200,6 +200,7 @@ buildErrorMessage httpError =
 textStyles : List (Element.Attribute msg)
 textStyles =
     [ centerX
+    , height fill
     , padding (gridSize * 10)
     ]
 


### PR DESCRIPTION
footer now is stuck to bottom of screen when loading spinner is spinning
