### PR TITLE
web: fix spinner v-align, banner copy

### DIFF
--- a/web/src/Banner/Banner.elm
+++ b/web/src/Banner/Banner.elm
@@ -82,7 +82,7 @@ body : Body
 body =
     { size = Styles.bodySize
     , color = Styles.bodyColor
-    , text = "Find more things for your thing do-er to do"
+    , text = "Find more things for your thing-doer to do"
     , font = Styles.bodyFont
     , width = Styles.bodyWidth
     }

--- a/web/src/Main.elm
+++ b/web/src/Main.elm
@@ -3,8 +3,8 @@ module Main exposing (Model, Msg(..), Page(..), buildErrorMessage, main, resourc
 import Banner.View as Banner exposing (view)
 import Browser exposing (UrlRequest(..))
 import Browser.Navigation as Nav
-import Common.Common exposing (ResourceType, gridSize)
-import Element exposing (Element, centerX, column, el, fill, height, html, padding, text, width)
+import Common.Common exposing (ResourceType)
+import Element exposing (Element, centerX, centerY, column, el, fill, height, html, text, width)
 import Footer.View as Footer exposing (view)
 import Html exposing (a, div, img, nav)
 import Html.Attributes exposing (class, href, src)
@@ -199,9 +199,7 @@ buildErrorMessage httpError =
 
 textStyles : List (Element.Attribute msg)
 textStyles =
-    [ centerX
-    , padding (gridSize * 10)
-    ]
+    [ centerX, centerY ]
 
 
 spinner : Element msg

--- a/web/tests/Banner/BannerTests.elm
+++ b/web/tests/Banner/BannerTests.elm
@@ -61,7 +61,7 @@ suite =
             , test "has text" <|
                 \_ ->
                     bannerBody.text
-                        |> Expect.equal "Find more things for your thing do-er to do"
+                        |> Expect.equal "Find more things for your thing-doer to do"
             , test "has a font" <|
                 \_ ->
                     bannerBody.font


### PR DESCRIPTION
- make the spinner on loading data vertically centered
- change thing do-er to thing-doer (good snag @pivotal-jamie-klassen)
