### PR TITLE
web: capitalize without additional package

### DIFF
--- a/web/elm.json
+++ b/web/elm.json
@@ -13,14 +13,12 @@
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
             "elm/url": "1.0.0",
-            "elm-community/string-extra": "4.0.1",
             "krisajenkins/remotedata": "6.0.1",
             "mdgriffith/elm-ui": "1.1.5"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
-            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2"
         }

--- a/web/src/Card/View.elm
+++ b/web/src/Card/View.elm
@@ -1,7 +1,7 @@
 module Card.View exposing (view)
 
 import Card.Card exposing (Author, Description, Github, Name, card)
-import Common.Common exposing (ResourceType)
+import Common.Common exposing (ResourceType, capitalize)
 import Common.Overrides as Overrides exposing (ellipsis, multiLineEllipsis)
 import Element
     exposing
@@ -30,7 +30,6 @@ import Element
 import Element.Border exposing (rounded, shadow)
 import Element.Font as Font exposing (color, family, size, typeface)
 import Html
-import String.Extra exposing (toSentenceCase)
 
 
 padding : { top : Int, right : Int, bottom : Int, left : Int }
@@ -117,7 +116,7 @@ description resourceType styles =
         [ html
             (Html.div
                 (Overrides.multiLineEllipsis 3)
-                [ Html.text (toSentenceCase resourceType.description) ]
+                [ Html.text (capitalize resourceType.description) ]
             )
         ]
 

--- a/web/src/Common/Common.elm
+++ b/web/src/Common/Common.elm
@@ -3,6 +3,7 @@ module Common.Common exposing
     , ResourceType
     , Shadow
     , bannerBackgroundColor
+    , capitalize
     , cardDescriptionColor
     , cardTitleColor
     , center
@@ -100,3 +101,12 @@ footerBackgroundColor =
 termsLinkColor : RGB
 termsLinkColor =
     { red = 12, green = 106, blue = 246, alpha = 1 }
+
+
+
+-- HELPERS
+
+
+capitalize : String -> String
+capitalize s =
+    (String.left 1 s |> String.toUpper) ++ String.dropLeft 1 s


### PR DESCRIPTION
we were previously using an elm-community package called string.extra for just capitalizing the beginning of the card description! @pivotal-jamie-klassen is totally correct in both that it isn't a core elm library and it's overkill! [see here](https://github.com/concourse/resource-types-website/pull/183#issuecomment-578296671)

anywho! here's a simple capitalization helper! re-usable and only using String!