### PR TITLE
fix pipeline to push the latest resource types

### DIFF
--- a/ci/tasks/update-resource-types.yml
+++ b/ci/tasks/update-resource-types.yml
@@ -8,5 +8,8 @@ image_resource:
 inputs:
   - name: resource-types-website
 
+outputs:
+  - name: resource-types-website
+
 run:
   path: resource-types-website/ci/tasks/scripts/update-resource-types


### PR DESCRIPTION
Turns out that we were not outputting the latest `resource-types-website` from the task

fixes: #208 