### PR TITLE
Add support for non-github repos

### DIFF
--- a/warehouse/githubwrapper/githubwrapper_test.go
+++ b/warehouse/githubwrapper/githubwrapper_test.go
@@ -15,14 +15,14 @@ var _ = Describe("github wrapper", func() {
 		var (
 			testServer *ghttp.Server
 			wrapper    githubwrapper.Wrapper
-			testStars  map[string]int
+			testStars  map[string]bool
 		)
 		BeforeEach(func() {
 			testServer = ghttp.NewServer()
 
 			wrapper = githubwrapper.NewWrapper(testServer.URL(), "token")
-			testStars = make(map[string]int)
-			testStars["concourse/concourse"] = 0
+			testStars = make(map[string]bool)
+			testStars["concourse/concourse"] = true
 		})
 
 		It("the underlying module does the appropriate call to the graphql api", func() {
@@ -37,13 +37,13 @@ var _ = Describe("github wrapper", func() {
 				),
 			)
 
-			testStars, err := wrapper.GetStars(testStars)
+			returnStars, err := wrapper.GetStars(testStars)
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(testStars["concourse/concourse"]).To(Equal(9))
+			Expect(returnStars["concourse/concourse"]).To(Equal(9))
 		})
 
-		It("return the appropriate error in case of server failure", func() {
+		It("returns the appropriate error in case of server failure", func() {
 			testServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", "/"),

--- a/warehouse/githubwrapper/githubwrapperfakes/fake_wrapper.go
+++ b/warehouse/githubwrapper/githubwrapperfakes/fake_wrapper.go
@@ -8,10 +8,10 @@ import (
 )
 
 type FakeWrapper struct {
-	GetStarsStub        func(map[string]int) (map[string]int, error)
+	GetStarsStub        func(map[string]bool) (map[string]int, error)
 	getStarsMutex       sync.RWMutex
 	getStarsArgsForCall []struct {
-		arg1 map[string]int
+		arg1 map[string]bool
 	}
 	getStarsReturns struct {
 		result1 map[string]int
@@ -25,11 +25,11 @@ type FakeWrapper struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeWrapper) GetStars(arg1 map[string]int) (map[string]int, error) {
+func (fake *FakeWrapper) GetStars(arg1 map[string]bool) (map[string]int, error) {
 	fake.getStarsMutex.Lock()
 	ret, specificReturn := fake.getStarsReturnsOnCall[len(fake.getStarsArgsForCall)]
 	fake.getStarsArgsForCall = append(fake.getStarsArgsForCall, struct {
-		arg1 map[string]int
+		arg1 map[string]bool
 	}{arg1})
 	fake.recordInvocation("GetStars", []interface{}{arg1})
 	fake.getStarsMutex.Unlock()
@@ -49,13 +49,13 @@ func (fake *FakeWrapper) GetStarsCallCount() int {
 	return len(fake.getStarsArgsForCall)
 }
 
-func (fake *FakeWrapper) GetStarsCalls(stub func(map[string]int) (map[string]int, error)) {
+func (fake *FakeWrapper) GetStarsCalls(stub func(map[string]bool) (map[string]int, error)) {
 	fake.getStarsMutex.Lock()
 	defer fake.getStarsMutex.Unlock()
 	fake.GetStarsStub = stub
 }
 
-func (fake *FakeWrapper) GetStarsArgsForCall(i int) map[string]int {
+func (fake *FakeWrapper) GetStarsArgsForCall(i int) map[string]bool {
 	fake.getStarsMutex.RLock()
 	defer fake.getStarsMutex.RUnlock()
 	argsForCall := fake.getStarsArgsForCall[i]

--- a/warehouse/githubwrapper/wrapper.go
+++ b/warehouse/githubwrapper/wrapper.go
@@ -28,6 +28,10 @@ func NewWrapper(serverUrl, token string) wrapper {
 	}
 }
 
+// the function does a workaround the github graphql
+// the grapphql expects a generic struct to be passed to it.
+// in our case we have no prior knowledge of some fields of the struct, or their values
+// that's why we used reflections to construct a struct object in the same way that is expected by the graphql.
 func (w wrapper) GetStars(repoStarsMap map[string]bool) (map[string]int, error) {
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: w.Token},

--- a/warehouse/githubwrapper/wrapper.go
+++ b/warehouse/githubwrapper/wrapper.go
@@ -13,7 +13,7 @@ import (
 //go:generate counterfeiter . Wrapper
 
 type Wrapper interface {
-	GetStars(map[string]int) (map[string]int, error)
+	GetStars(map[string]bool) (map[string]int, error)
 }
 
 type wrapper struct {
@@ -28,7 +28,7 @@ func NewWrapper(serverUrl, token string) wrapper {
 	}
 }
 
-func (w wrapper) GetStars(repoStarsMap map[string]int) (map[string]int, error) {
+func (w wrapper) GetStars(repoStarsMap map[string]bool) (map[string]int, error) {
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: w.Token},
 	)
@@ -47,14 +47,16 @@ func (w wrapper) GetStars(repoStarsMap map[string]int) (map[string]int, error) {
 	ghReturnReflection := reflect.TypeOf(ghReturn{})
 
 	i := 0
-	for k := range repoStarsMap {
-		strs := strings.Split(k, "/")
-		arr = append(arr, reflect.StructField{
-			Name: fmt.Sprintf("I%d", i),
-			Type: ghReturnReflection,
-			Tag:  reflect.StructTag(fmt.Sprintf(`graphql:"i%d: repository(owner: \"%s\", name: \"%s\")"`, i, strs[0], strs[1])),
-		})
-		i++
+	for k, isGithub := range repoStarsMap {
+		if isGithub {
+			strs := strings.Split(k, "/")
+			arr = append(arr, reflect.StructField{
+				Name: fmt.Sprintf("I%d", i),
+				Type: ghReturnReflection,
+				Tag:  reflect.StructTag(fmt.Sprintf(`graphql:"i%d: repository(owner: \"%s\", name: \"%s\")"`, i, strs[0], strs[1])),
+			})
+			i++
+		}
 	}
 
 	gqlQuery := reflect.New(reflect.StructOf(arr)).Elem()
@@ -66,11 +68,14 @@ func (w wrapper) GetStars(repoStarsMap map[string]int) (map[string]int, error) {
 
 	i = 0
 
-	for range repoStarsMap {
-		stars := reflect.ValueOf(gqlQuery.Interface()).FieldByIndex([]int{i}).FieldByName("Stargazers").FieldByIndex([]int{0}).Interface().(int)
-		owner := reflect.ValueOf(gqlQuery.Interface()).FieldByIndex([]int{i}).FieldByName("NameWithOwner").Interface().(string)
-		repoStarsMap[owner] = stars
-		i++
+	returnMap := make(map[string]int)
+	for _, isGithub := range repoStarsMap {
+		if isGithub {
+			stars := reflect.ValueOf(gqlQuery.Interface()).FieldByIndex([]int{i}).FieldByName("Stargazers").FieldByIndex([]int{0}).Interface().(int)
+			owner := reflect.ValueOf(gqlQuery.Interface()).FieldByIndex([]int{i}).FieldByName("NameWithOwner").Interface().(string)
+			returnMap[owner] = stars
+			i++
+		}
 	}
-	return repoStarsMap, nil
+	return returnMap, nil
 }

--- a/warehouse/go.sum
+++ b/warehouse/go.sum
@@ -69,6 +69,7 @@ github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:x
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
+github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -285,6 +286,7 @@ google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
+google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/warehouse/persistence/filesystem.go
+++ b/warehouse/persistence/filesystem.go
@@ -50,6 +50,8 @@ func (fs *Filesystem) LoadResources() error {
 			}
 			currResource.Owner += parsedRepo.Owner
 
+			currResource.Host = parsedRepo.Host
+
 			currResource.NameWithOwner = parsedRepo.Owner + "/" + parsedRepo.Name
 			resourcesMap[currResource.NameWithOwner] = parsedRepo.IsGithub
 
@@ -87,6 +89,7 @@ func formatStars(stars int) string {
 }
 
 type Repo struct {
+	Host     string
 	Owner    string
 	Name     string
 	IsGithub bool
@@ -100,9 +103,12 @@ func parseRepoURL(sourceURL string) (Repo, error) {
 		return Repo{}, err
 	}
 	parts := strings.Split(u.Path, "/")
+
 	if strings.Contains(u.Host, "github") {
 		parsedRepo.IsGithub = true
 	}
+
+	parsedRepo.Host = strings.Split(u.Host, ".")[0]
 
 	if len(parts) == 2 {
 		parsedRepo.Name = parts[1]

--- a/warehouse/persistence/filesystem.go
+++ b/warehouse/persistence/filesystem.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -28,7 +29,7 @@ func (fs *Filesystem) LoadResources() error {
 		return err
 	}
 
-	resourcesMap := make(map[string]int)
+	resourcesMap := make(map[string]bool)
 
 	for _, fileBytes := range files {
 		if strings.Contains(fileBytes.Name, ".yml") || strings.Contains(fileBytes.Name, ".yaml") {
@@ -39,26 +40,31 @@ func (fs *Filesystem) LoadResources() error {
 				return err
 			}
 
-			var repoName, owner string
-			owner, repoName = extractOwnerAndRepo(currResource.URL)
+			parsedRepo, err := parseRepoURL(currResource.URL)
+			if err != nil {
+				return err
+			}
 
-			currResource.Owner = "@" + owner
+			if len(parsedRepo.Owner) > 0 {
+				currResource.Owner = "@"
+			}
+			currResource.Owner += parsedRepo.Owner
 
-			currResource.NameWithOwner = owner + "/" + repoName
-			resourcesMap[currResource.NameWithOwner] = 0
+			currResource.NameWithOwner = parsedRepo.Owner + "/" + parsedRepo.Name
+			resourcesMap[currResource.NameWithOwner] = parsedRepo.IsGithub
 
 			fs.resources = append(fs.resources, currResource)
 		}
 	}
 
 	//TODO: doesn't look like the best way is to call github gql here :thinking:
-	resourcesMap, err = fs.GhGqlWrapper.GetStars(resourcesMap)
+	resourcesStars, err := fs.GhGqlWrapper.GetStars(resourcesMap)
 	if err != nil {
 		return err
 	}
 
 	for i, curr := range fs.resources {
-		fs.resources[i].StarsCount = resourcesMap[curr.NameWithOwner]
+		fs.resources[i].StarsCount = resourcesStars[curr.NameWithOwner]
 		fs.resources[i].Stars = formatStars(fs.resources[i].StarsCount)
 	}
 
@@ -80,8 +86,31 @@ func formatStars(stars int) string {
 	}
 }
 
-func extractOwnerAndRepo(url string) (string, string) {
-	urlNoGit := strings.Replace(url, ".git", "", 1)
-	parts := strings.Split(urlNoGit, "/")
-	return parts[len(parts)-2], parts[len(parts)-1]
+type Repo struct {
+	Owner    string
+	Name     string
+	IsGithub bool
+}
+
+func parseRepoURL(sourceURL string) (Repo, error) {
+	// fmt.Println(sourceURL)
+	var parsedRepo Repo
+	u, err := url.Parse(strings.ToLower(sourceURL))
+	if err != nil {
+		return Repo{}, err
+	}
+	parts := strings.Split(u.Path, "/")
+	if strings.Contains(u.Host, "github") {
+		parsedRepo.IsGithub = true
+	}
+
+	if len(parts) == 2 {
+		parsedRepo.Name = parts[1]
+		parsedRepo.Owner = ""
+		return parsedRepo, nil
+	}
+
+	parsedRepo.Name = parts[2]
+	parsedRepo.Owner = parts[1]
+	return parsedRepo, nil
 }

--- a/warehouse/persistence/filesystem.go
+++ b/warehouse/persistence/filesystem.go
@@ -96,7 +96,6 @@ type Repo struct {
 }
 
 func parseRepoURL(sourceURL string) (Repo, error) {
-	// fmt.Println(sourceURL)
 	var parsedRepo Repo
 	u, err := url.Parse(strings.ToLower(sourceURL))
 	if err != nil {

--- a/warehouse/resource/resource.go
+++ b/warehouse/resource/resource.go
@@ -8,5 +8,6 @@ type Resource struct {
 	Owner         string `json:"username"`
 	Stars         string `json:"stars"`
 	StarsCount    int    `json:"stars_count"`
+	Host          string `json:"host"`
 	NameWithOwner string
 }

--- a/warehouse/resource/resource_test.go
+++ b/warehouse/resource/resource_test.go
@@ -19,7 +19,8 @@ var _ = Describe("Resource model", func() {
 				"repo": "https://github.com/concourse/test",
 				"description": "test description",
 				"stars": "8K",
-				"stars_count": 8040
+				"stars_count": 8040,
+				"host": "github"
 			}`
 			err := json.Unmarshal([]byte(jsonResource), &resource)
 			Expect(err).NotTo(HaveOccurred())
@@ -28,6 +29,7 @@ var _ = Describe("Resource model", func() {
 			Expect(resource.Description).To(Equal("test description"))
 			Expect(resource.Stars).To(Equal("8K"))
 			Expect(resource.StarsCount).To(Equal(8040))
+			Expect(resource.Host).To(Equal("github"))
 		})
 	})
 })

--- a/warehouse/server/server_test.go
+++ b/warehouse/server/server_test.go
@@ -83,6 +83,7 @@ var _ = Describe("Server Test", func() {
 			Expect(len(reses)).To(Equal(1))
 			Expect(reses[0].Name).To(Equal("git"))
 			Expect(reses[0].Stars).To(Equal("10"))
+			Expect(reses[0].Host).To(Equal("github"))
 		})
 		It("returns 404 on calls to unknown api /api/v1/res", func() {
 			resp, err := http.Get("http://" + serverAddr + "/api/v1/res")


### PR DESCRIPTION
- With this [PR](https://github.com/concourse/resource-types/pull/47), I noticed that the current code wouldn't work with non-github repositories and even panicking the whole server.

- This is because we were trying to get the stars of a repo regardless where it is hosted.

- This PR will allow to only call the Github graphql when the repo is hosted under Github.
- Also, for the aforementioned PR, the URL doesn't contain a part for the owner, I also handled that.

- @jomsie, we might need to do some tweaks to the UI, as when I return the `owner` as empty string it kinda messes with the way it is displayed. I also noticed that there is no way to hide the Github stars icon, which in this case will be irrelevant.

