### PR TITLE
web: fix yarn build command for web

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "analyse": "cd web && elm-analyse",
     "build-dev": "cd web && elm make src/Main.elm --output public/elm.js",
-    "build": "cd web && elm make --optimize --output public/elm.js src/Main.elm && uglifyjs public/elm.js --compress 'pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe' | uglifyjs --mangle --output=public/elm.min.js",
+    "build": "cd web && elm make --optimize --output public/elm.js src/Main.elm && uglifyjs public/elm.js --compress 'pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe' | uglifyjs --mangle --output public/elm.min.js",
     "test": "cd web && elm-test"
   }
 }


### PR DESCRIPTION
uglify js changed so now --output needs to have a space, not an equals sign.