### PR TITLE
Fixes Sanity Check for Get errors:

### DIFF
--- a/warehouse/sanity-check/main.go
+++ b/warehouse/sanity-check/main.go
@@ -56,13 +56,16 @@ func main() {
 
 			res, err := client.Get(currResource.URL)
 			if err != nil {
-				panic(err)
+				errors = append(errors, "In: "+fileBytes.Name+","+red.Sprintf(currResource.URL+" Get error "+err.Error()))
+				printColor(red, "checked: ", fileBytes.Name)
+				continue
 			}
 			if res.StatusCode == http.StatusMovedPermanently {
 				movedLocation, _ := res.Location()
 				errors = append(errors, "In: "+fileBytes.Name+","+red.Sprintf(" Repo "+currResource.URL+" moved ----> "+movedLocation.String()))
 				failed = false
 			}
+
 			if res.StatusCode == http.StatusNotFound {
 				errors = append(errors, "In: "+fileBytes.Name+","+red.Sprintf(" Repo "+currResource.URL+" Not Found"))
 				failed = false


### PR DESCRIPTION
- One of the current source codes had problems with the server since it
is not hosted on Github, so the error was unexpected resulting in a
panic in the Sanity check although it should have marked this as an
error.

- This updates the Sanity check to add http.Get errors as problems
instead of panicing.

